### PR TITLE
Add capitalized version of abbreviation

### DIFF
--- a/docs/01-paper.md
+++ b/docs/01-paper.md
@@ -67,6 +67,7 @@ abbreviations:
   fMRI: functional Magnetic Resonance Imaging
   ANN: Artificial Neural Network
   fcHNN: functional connectome-based Hopfield Neural Network
+  FcHNN: functional connectome-based Hopfield Neural Network
   HNN: Hopfield Neural Network
   PC: Principal Component
   ABIDE: Autism Brain Imaging Data Exchange


### PR DESCRIPTION
Adds the capitalized version of the fcHNN abbreviation. This was in keypoints and a few other places!

![image](https://github.com/pni-lab/connattractor/assets/913249/de911dfd-e00d-4b35-b06f-877ff1cb82e2)
