### PR TITLE
Fix link to webpage with manuscript and getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Laboratory for Predictive Neuroimaging - University Hospital Essen, Germany
 
 ## Webpage with manuscript and getting started guide
-[pni-lab.github.io/connattractor](pni-lab.github.io/connattractor)
+[https://pni-lab.github.io/connattractor](https://pni-lab.github.io/connattractor)
 
 ## How to install the connattractor package?
 


### PR DESCRIPTION
Current link leads to "404 - page not found".
"https://" was needed for GitHub to recognize that we want to visit a website and not a file inside the repository.